### PR TITLE
Fixed address

### DIFF
--- a/config/dhcp_infoblox.yml
+++ b/config/dhcp_infoblox.yml
@@ -6,3 +6,9 @@
 # Infoblox settings:
 :infoblox_user: "infoblox"
 :infoblox_pw: "infoblox"
+#Record type to manage. Can be "host" or "fixed_address"
+:record_type: 'host'
+#infoblox api version
+:wapi_version: '2.0'
+#Use  pre-definded ranges in networks to find available IP's
+:range: false

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_main.rb
@@ -13,7 +13,12 @@ module Proxy::DHCP::Infoblox
       server = Proxy::DhcpPlugin.settings.server
       infoblox_user = Proxy::DHCP::Infoblox::Plugin.settings.infoblox_user
       infoblox_pw = Proxy::DHCP::Infoblox::Plugin.settings.infoblox_pw
+      @record_type = Proxy::DHCP::Infoblox::Plugin.settings.record_type
+      wapi_version = Proxy::DHCP::Infoblox::Plugin.settings.wapi_version
+      @range = Proxy::DHCP::Infoblox::Plugin.settings.range
+      ::Infoblox.wapi_version = "#{wapi_version}"
       @connection = ::Infoblox::Connection.new(username: infoblox_user, password: infoblox_pw, host: server)
+      logger.debug "Loaded infoblox provider with #{@record_type} record_type and #{wapi_version} wapi_version"
     end
 
     def initialize_for_testing(params)
@@ -22,6 +27,8 @@ module Proxy::DHCP::Infoblox
       @dhcp_server = params[:dhcp_server] || @dhcp_server
       @username = params[:username] || @username
       @password = params[:password] || @password
+      @record_type = params[:record_type] || @record_type
+      @wapi_version = params[:wapi_version] || @wapi_version
       self
     end
 
@@ -51,24 +58,35 @@ module Proxy::DHCP::Infoblox
     def load_infoblox_subnet_data(subnet)
       # Load network from infoblox, iterate over ips to gather additional settings
       logger.debug 'load_infoblox_subnet_data'
-      # max results are currently set to work in my setup, one could calculate that setting by looking at netmask :)
-      network = ::Infoblox::Ipv4address.find(@connection, 'network' => "#{subnet.network}/#{subnet.cidr}", 'status' => 'USED', 'usage' => 'DHCP', '_max_results' => 2**(32-subnet.cidr))
-      # Find out which hosts are in use
-      network.each do |host|
-        # next if certain values are not set
-        next if host.names.empty? || host.mac_address.empty? || host.ip_address.empty?
-        hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'ipv4addr' => host.ip_address).first
-        next unless hostdhcp.configure_for_dhcp
-        opts = { :hostname => host.names.first }
-        opts[:mac] = host.mac_address
-        opts[:ip] = host.ip_address
-        # broadcast and network entrys are not deleteable
-        opts[:deleteable] = true unless (host.types & %w(BROADCAST NETWORK)).any?
-        opts[:nextServer] = hostdhcp.nextserver unless hostdhcp.use_nextserver
-        opts[:filename] = hostdhcp.bootfile unless hostdhcp.use_bootfile
-        service.add_host(subnet.network, Proxy::DHCP::Reservation.new(opts.merge(:subnet => subnet)))
+      if @record_type == 'host'
+        # max results are currently set to work in my setup, one could calculate that setting by looking at netmask :)
+        network = ::Infoblox::Ipv4address.find(@connection, 'network' => "#{subnet.network}/#{subnet.cidr}", 'status' => 'USED', 'usage' => 'DHCP', '_max_results' => 2**(32-subnet.cidr))
+        # Find out which hosts are in use
+        network.each do |host|
+          # next if certain values are not set
+          next if host.names.empty? || host.mac_address.empty? || host.ip_address.empty?
+          hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'ipv4addr' => host.ip_address).first
+          next unless hostdhcp.configure_for_dhcp
+          opts = { :hostname => host.names.first }
+          opts[:mac] = host.mac_address
+          opts[:ip] = host.ip_address
+          # broadcast and network entrys are not deleteable
+          opts[:deleteable] = true unless (host.types & %w(BROADCAST NETWORK)).any?
+          opts[:nextServer] = hostdhcp.nextserver unless hostdhcp.use_nextserver
+          opts[:filename] = hostdhcp.bootfile unless hostdhcp.use_bootfile
+          service.add_host(subnet.network, Proxy::DHCP::Reservation.new(opts.merge(:subnet => subnet)))
+	      end
+      elsif @record_type == 'fixed_address'
+	       network = ::Infoblox::Fixedaddress.find(@connection, 'network' => "#{subnet.network}/#{subnet.cidr}", '_max_results' => 2**(32-subnet.cidr))
+         network.each do |host|
+	          logger.debug "Processing host: #{host.name} #{host.mac} #{host.ipv4addr}"
+	          next if host.name == nil || host.mac == nil || host.ipv4addr == nil
+            opts = { :hostname => host.name }
+            opts[:mac] = host.mac
+            opts[:ip] = host.ipv4addr
+            service.add_host(subnet.network, Proxy::DHCP::Reservation.new(opts.merge(:subnet => subnet)))
+	      end
       end
-
     end
 
     def all_hosts(network_address)
@@ -82,33 +100,50 @@ module Proxy::DHCP::Infoblox
       # returns first available ip address in a subnet with network_address, for a host with mac_address, in the range of ip addresses: from_ip_address, to_ip_address
       # Deliberatly ignoring everything but first argument
       logger.debug "Infoblox unused_ip Network_address: #{network_address} #{mac_address}, #{from_ip_address}, #{to_ip_address}"
-      ::Infoblox::Network.find(@connection, network: "#{network_address.network}/#{network_address.cidr}").first.next_available_ip
-      # Idea for randomisation in case of concurrent installs:
-      #::Infoblox::Network.find(@connection, network: "#{network_address.network}/#{network_address.cidr}").first.next_available_ip(15).sample
+      if @range == true
+        ::Infoblox::Range.find(@connection, network: "#{network_address.network}/#{network_address.cidr}").first.next_available_ip
+      else
+        ::Infoblox::Network.find(@connection, network: "#{network_address.network}/#{network_address.cidr}").first.next_available_ip
+        # Idea for randomisation in case of concurrent installs:
+        #::Infoblox::Network.find(@connection, network: "#{network_address.network}/#{network_address.cidr}").first.next_available_ip(15).sample
+      end
     end
 
     def find_record(subnet_address, an_address)
       logger.debug 'find_record'
       # record can be either ip or mac, true = mac --> lookup ip
       if an_address.is_a?(String) && valid_mac?(an_address)
-        hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'mac' => an_address)
+        if @record_type == 'host'
+          hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'mac' => an_address)
+        elsif @record_type == 'fixed_address'
+          hostdhcp = ::Infoblox::Fixedaddress.find(@connection,'mac' => an_address)
+        end
         return nil if hostdhcp.empty?
         ipv4address = hostdhcp.first.ipv4addr
       elsif an_address.is_a?(String)
         validate_ip(an_address)
         ipv4address = an_address
       end
-      host = ::Infoblox::Host.find(@connection, 'ipv4addr' => ipv4address)
-      return nil if host.empty? || host.first.name.empty?
-      hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'ipv4addr' => ipv4address).first
-      return nil unless hostdhcp.configure_for_dhcp
-      return nil if hostdhcp.mac.empty? || hostdhcp.ipv4addr.empty?
-      opts = { :hostname => host.first.name }
-      opts[:mac] = hostdhcp.mac
-      opts[:ip] = hostdhcp.ipv4addr
-      opts[:deleteable] = true
-      opts[:nextServer] = hostdhcp.nextserver if hostdhcp.use_nextserver
-      opts[:filename] = hostdhcp.bootfile if hostdhcp.use_bootfile
+
+      if @record_type == 'host'
+        host = ::Infoblox::Host.find(@connection, 'ipv4addr' => ipv4address)
+        return nil if host.empty? || host.first.name.empty?
+        hostdhcp = ::Infoblox::HostIpv4addr.find(@connection, 'ipv4addr' => ipv4address).first
+        return nil unless hostdhcp.configure_for_dhcp
+        return nil if hostdhcp.mac.empty? || hostdhcp.ipv4addr.empty?
+        opts = { :hostname => host.first.name }
+        opts[:mac] = hostdhcp.mac
+        opts[:ip] = hostdhcp.ipv4addr
+        opts[:deleteable] = true
+        opts[:nextServer] = hostdhcp.nextserver if hostdhcp.use_nextserver
+        opts[:filename] = hostdhcp.bootfile if hostdhcp.use_bootfile
+      elsif @record_type == 'fixed_address'
+        fixed_address = ::Infoblox::Fixedaddress.find(@connection, 'ipv4addr' => ipv4address)
+        return nil if fixed_address.emtpy? || fixed_address.first.name.empty?
+        opts = { :hostname => fixed_address.first.name }
+        opts[:mac] = fixed_address.first.mac
+        opts[:ip] = fixed_address.first.ipv4addr
+      end
       # Subnet should only be one, not checking that yet
       subnet = subnets.find { |s| s.include? ipv4address }
       Proxy::DHCP::Record.new(opts.merge(:subnet => subnet))
@@ -122,34 +157,48 @@ module Proxy::DHCP::Infoblox
       host.post
     end
 
+    def create_infoblox_fixed_address(record)
+      logger.debug 'create_infoblox_fixed_address'
+      fixed_address = ::Infoblox::Fixedaddress.new(:connection => @connection)
+      fixed_address.name = record.name
+      fixed_address.ipv4addr = record.ip
+      fixed_address.mac = record.mac
+      fixed_address.post
+    end
+
     def add_record options={}
       logger.debug 'Add Record'
       record = super
-      
-      host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip)
-      # If empty create:
-      if host.empty?
-        create_infoblox_host_record(record)
+      #Since we support 2 types of records, do the right thing with each one.
+      if @record_type == 'host'
+        host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip)
+        # If empty create:
+        if host.empty?
+          create_infoblox_host_record(record)
+        end
+        host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip).first
+        options = record.options
+        # Overwrite values without checking
+        # Select correct ipv4addr object from ipv4addrs array
+        hostip = host.ipv4addrs.find { |ip| ip.ipv4addr == record.ip }
+        logger.debug "Add Record - record.name: #{record.name}, hostip.host #{hostip.host}, record.mac #{record.mac}, record.ip #{record.ip}"
+        logger.debug "Add Record - options[:nextServer] #{options[:nextServer]}, options[:filename] #{options[:filename]}, hostip.ipv4addr: #{hostip.ipv4addr} "
+        raise InvalidRecord, "#{record} Hostname mismatch" unless hostip.host == record.name
+        hostip.mac = record.mac
+        hostip.configure_for_dhcp = true
+        hostip.nextserver = options[:nextServer]
+        hostip.use_nextserver = true
+        hostip.bootfile = options[:filename]
+        hostip.use_bootfile = true
+        ## Test if Host Entry has correct IP
+        raise InvalidRecord, "#{record} IP mismatch" unless hostip.ipv4addr == record.ip
+        # Send object
+        host.put
+        record
+      elsif @record_type == 'fixed_address'
+        create_infoblox_fixed_address(record)
+        record
       end
-      host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip).first
-      options = record.options
-      # Overwrite values without checking
-      # Select correct ipv4addr object from ipv4addrs array
-      hostip = host.ipv4addrs.find { |ip| ip.ipv4addr == record.ip }
-      logger.debug "Add Record - record.name: #{record.name}, hostip.host #{hostip.host}, record.mac #{record.mac}, record.ip #{record.ip}"
-      logger.debug "Add Record - options[:nextServer] #{options[:nextServer]}, options[:filename] #{options[:filename]}, hostip.ipv4addr: #{hostip.ipv4addr} "
-      raise InvalidRecord, "#{record} Hostname mismatch" unless hostip.host == record.name
-      hostip.mac = record.mac
-      hostip.configure_for_dhcp = true
-      hostip.nextserver = options[:nextServer]
-      hostip.use_nextserver = true
-      hostip.bootfile = options[:filename]
-      hostip.use_bootfile = true
-      ## Test if Host Entry has correct IP
-      raise InvalidRecord, "#{record} IP mismatch" unless hostip.ipv4addr == record.ip
-      # Send object
-      host.put
-      record
     end
 
     def del_record subnet, record
@@ -158,17 +207,24 @@ module Proxy::DHCP::Infoblox
       validate_record record
       # TODO: Refactor this into the base class
       raise InvalidRecord, "#{record} is static - unable to delete" unless record.deleteable?
-      # "Deleting" a record here means just disabling dhcp
-      host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip)
-      unless host.empty?
-        # if not empty, first element is what we want to edit
-        host = host.first
-        # Select correct ipv4addr object from ipv4addrs array
-        hostip = host.ipv4addrs.find { |ip| ip.ipv4addr == record.ip }
-        hostip.configure_for_dhcp = false
-        # Send object
-        host.put
+      if @record_type == 'host'
+        # "Deleting" a record here means just disabling dhcp
+        host = ::Infoblox::Host.find(@connection, 'ipv4addr' => record.ip)
+        unless host.empty?
+          # if not empty, first element is what we want to edit
+          host = host.first
+          # Select correct ipv4addr object from ipv4addrs array
+          hostip = host.ipv4addrs.find { |ip| ip.ipv4addr == record.ip }
+          hostip.configure_for_dhcp = false
+          # Send object
+          host.put
+        end
+      elsif @record_type == 'fixed_address'
+        #Delete the fixed address record.
+        fixed_address = Infoblox::Fixedaddress.find(@connection, {ipv4addr: record.ip, mac: record.mac}).first
+        fixed_address.delete
       end
+
       logger.debug "Disabled DHCP on #{record}"
     end
   end

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
@@ -7,7 +7,12 @@ module Proxy::DHCP::Infoblox
     # Settings listed under default_settings are required.
     # An exception will be raised if they are initialized with nil values.
     # Settings not listed under default_settings are considered optional and by default have nil value.
-    default_settings :infoblox_user => 'infoblox', :infoblox_pw => 'infoblox', :infoblox_host => 'infoblox.my.domain'
+    default_settings :infoblox_user => 'infoblox',
+     :infoblox_pw => 'infoblox',
+     :infoblox_host => 'infoblox.my.domain',
+     :record_type => 'host',
+     :wapi_version => '2.0'
+     :range => false
 
     requires :dhcp, '>= 1.11'
 

--- a/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
+++ b/lib/smart_proxy_dhcp_infoblox/dhcp_infoblox_plugin.rb
@@ -11,7 +11,7 @@ module Proxy::DHCP::Infoblox
      :infoblox_pw => 'infoblox',
      :infoblox_host => 'infoblox.my.domain',
      :record_type => 'host',
-     :wapi_version => '2.0'
+     :wapi_version => '2.0',
      :range => false
 
     requires :dhcp, '>= 1.11'


### PR DESCRIPTION
should fix #4 #5 #6 for my environment. 

The short story is, while we DO manage DNS with Infoblox as well, we manage things in a granular way: dhcp static reservations (fixed address), A records, and PTR records. Infoblox can do all of this w/ a "host" record, but we don't do that (more power to you if you do!). So this PR adds a config option to set the record type that will be managed (defaults to "host", can be "fixed_address' ). 

Also adds WAPI version setting since the fixed_address stuff seems to only work w/ 2.0+

Finally, also adds a "range" boolean config setting. We set a dhcp "range" per network, and want to choose from this range for IP addresses when looking for the next available. 

With these changes, in my environment, I can make new records, delete them, load subnet data, get next ips, etc. I need to test a bit more thoroughly, but, think this is basically working as expected right now. 